### PR TITLE
Add git to docker image

### DIFF
--- a/0.3.6/alpine/Dockerfile
+++ b/0.3.6/alpine/Dockerfile
@@ -12,6 +12,7 @@ RUN apk update \
  && apk --no-cache add \
       bash \
       curl \
+      git \
  && rm -rf /var/cache/apk/*
 
 RUN curl -L https://github.com/aelsabbahy/goss/releases/download/${GOSS_VER}/goss-linux-amd64 -o /usr/local/bin/goss && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project uses the version of main tool as main version number .
 ## [Unreleased]
 
 ### Added
+- Add git 
 - [#2] - Use common builders - 1.0.1
 - Add goss 
 


### PR DESCRIPTION
In some ci scripts we check the status of the scripts and therefor we need `git`